### PR TITLE
[Feat] Entity와 DTO의 분리 및 재고감소 로직 추가

### DIFF
--- a/ecService/src/main/java/com/wming/ecservice/controller/OrderController.java
+++ b/ecService/src/main/java/com/wming/ecservice/controller/OrderController.java
@@ -1,25 +1,28 @@
 package com.wming.ecservice.controller;
 
+import com.wming.ecservice.dto.OrderDTO;
 import com.wming.ecservice.service.OrderSerivce;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
 @RequestMapping("/orders")
 public class OrderController {
 
-    private OrderSerivce orderSerivce;
+  private OrderSerivce orderSerivce;
 
-    public OrderController(OrderSerivce orderSerivce) {
-        this.orderSerivce = orderSerivce;
-    }
+  public OrderController(OrderSerivce orderSerivce) {
+    this.orderSerivce = orderSerivce;
+  }
 
-    @PostMapping("/createOrder")
-    public String createOrder(@RequestParam("productId") Long productId, @RequestParam("quantity") int quantity) {
-        orderSerivce.createOrder(productId, quantity);
-        return "주문이 완료되었습니다.";
-    }
+  @PostMapping("/createOrder")
+  public String createOrder(@RequestBody OrderDTO orderDto) {
+    orderSerivce.createOrder(orderDto);
+    return "주문이 완료되었습니다.";
+  }
 }
 

--- a/ecService/src/main/java/com/wming/ecservice/dto/OrderDTO.java
+++ b/ecService/src/main/java/com/wming/ecservice/dto/OrderDTO.java
@@ -1,0 +1,23 @@
+package com.wming.ecservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class OrderDTO {
+
+  /*주문 번호*/
+  private long ordId;
+
+  /*상품 번호*/
+  private long productId;
+
+  /*상품 주문 수*/
+  private int quantity;
+
+}

--- a/ecService/src/main/java/com/wming/ecservice/entity/OrderEntity.java
+++ b/ecService/src/main/java/com/wming/ecservice/entity/OrderEntity.java
@@ -35,7 +35,7 @@ public class OrderEntity {
     this.isPaid = isPaid;
   }
 
-  public void processOrder() {
+  public void checkAndDecrementStock() {
     if (productEntity.getProductStock() >= quantity) {
       productEntity.reduceStock(quantity);
     } else {

--- a/ecService/src/main/java/com/wming/ecservice/entity/OrderEntity.java
+++ b/ecService/src/main/java/com/wming/ecservice/entity/OrderEntity.java
@@ -1,6 +1,10 @@
 package com.wming.ecservice.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,37 +12,39 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @NoArgsConstructor
-@AllArgsConstructor
-@Getter
 @Entity
 @Slf4j
+@Builder
+@AllArgsConstructor
+@Getter
 public class OrderEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long ordId;
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long ordId;
 
-    @ManyToOne // 주문은 하나의 상품과 매핑
-    private ProductEntity productEntity;
+  @ManyToOne // 주문은 하나의 상품과 매핑
+  private ProductEntity productEntity;
 
-    private int     quantity;
-    private boolean isPaid;
+  private int quantity;
+  private boolean isPaid;
 
-    public OrderEntity(ProductEntity productEntity, int quantity) {
-        this.productEntity = productEntity;
-        this.quantity = quantity;
+  public OrderEntity(ProductEntity productEntity, int quantity, boolean isPaid) {
+    this.productEntity = productEntity;
+    this.quantity = quantity;
+    this.isPaid = isPaid;
+  }
+
+  public void processOrder() {
+    if (productEntity.getProductStock() >= quantity) {
+      productEntity.reduceStock(quantity);
+    } else {
+      log.debug("재고 부족");
     }
+  }
 
-    public void processOrder() {
-        if (productEntity.getProductStock() >= quantity) {
-            productEntity.reduceStock(quantity);
-        } else {
-            log.debug("재고 부족");
-        }
-    }
-
-    public void pay() {
-        this.isPaid = true;
-        log.debug("결제 완료");
-    }
+  public void pay() {
+    this.isPaid = true;
+    log.debug("결제 완료");
+  }
 }

--- a/ecService/src/main/java/com/wming/ecservice/service/OrderSerivce.java
+++ b/ecService/src/main/java/com/wming/ecservice/service/OrderSerivce.java
@@ -1,5 +1,6 @@
 package com.wming.ecservice.service;
 
+import com.wming.ecservice.dto.OrderDTO;
 import com.wming.ecservice.entity.OrderEntity;
 import com.wming.ecservice.entity.ProductEntity;
 import com.wming.ecservice.repository.OrderRepository;
@@ -10,33 +11,59 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class OrderSerivce {
-    private ProductRepository productRepository;
-    private OrderRepository orderRepository;
 
-    @Autowired
-    public OrderSerivce(ProductRepository productRepository, OrderRepository orderRepository) {
-        this.productRepository = productRepository;
-        this.orderRepository = orderRepository;
-    }
+  private ProductRepository productRepository;
+  private OrderRepository orderRepository;
 
-    @Transactional
-    public void createOrder(Long prodId, int quantity) {
-        ProductEntity productEntity = productRepository.findById(prodId)
-                .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
+  @Autowired
+  public OrderSerivce(ProductRepository productRepository, OrderRepository orderRepository) {
+    this.productRepository = productRepository;
+    this.orderRepository = orderRepository;
+  }
 
-        OrderEntity orderEntity = new OrderEntity(productEntity , quantity);
-        orderEntity.processOrder();
-        orderRepository.save(orderEntity);
+  @Transactional
+  public void createOrder(OrderDTO orderDTO) {
+    //1. 상품 조회
+    ProductEntity productEntity = productRepository.findById(orderDTO.getProductId())
+        .orElseThrow(() -> new IllegalArgumentException("상품이 존재하지 않습니다."));
 
-        this.payOrder(orderEntity.getOrdId());
-    }
+    //2. 주문 엔티티 생성 후 저장
+    OrderEntity orderEntity = convertToEntity(productEntity, orderDTO);
+    orderEntity = orderRepository.save(orderEntity);
 
-    @Transactional
-    public void payOrder(Long orderId) {
-        OrderEntity orderEntity = orderRepository.findById(orderId)
-                .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
+    //3. 저장된 주문의 ID를 이용해 결제 처리
+    OrderDTO savedOrderDTO = convertToDTO(orderEntity);
+    this.payOrder(savedOrderDTO);
+  }
 
-        orderEntity.pay();
-        orderRepository.save(orderEntity);
-    }
+  @Transactional
+  public void payOrder(OrderDTO orderDto) {
+
+    //1. 주문 조회
+    OrderEntity orderEntity = orderRepository.findById(orderDto.getOrdId())
+        .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
+
+    //2. 결제 처리 로직
+    orderEntity.pay();
+
+    //3. 결제 상태 변경된 후 주문 다시 저장
+    orderRepository.save(orderEntity);
+  }
+
+  /* DTO -> Entity로 변환 */
+  public OrderEntity convertToEntity(ProductEntity productEntity, OrderDTO orderDTO) {
+    return OrderEntity.builder()
+        .productEntity(productEntity)
+        .quantity(orderDTO.getQuantity())
+        .build();
+  }
+
+  /* Entity로 -> DTO로 변환 */
+  public OrderDTO convertToDTO(OrderEntity orderEntity) {
+    return OrderDTO.builder()
+        .ordId(orderEntity.getOrdId())
+        .productId(orderEntity.getProductEntity().getProductId())
+        .quantity(orderEntity.getQuantity())
+        .build();
+  }
 }

--- a/ecService/src/main/java/com/wming/ecservice/service/OrderSerivce.java
+++ b/ecService/src/main/java/com/wming/ecservice/service/OrderSerivce.java
@@ -29,9 +29,14 @@ public class OrderSerivce {
 
     //2. 주문 엔티티 생성 후 저장
     OrderEntity orderEntity = convertToEntity(productEntity, orderDTO);
+
+    //3. 재고 확인 후 재고 감소
+    orderEntity.checkAndDecrementStock();
+
+    //4. 주문 저장
     orderEntity = orderRepository.save(orderEntity);
 
-    //3. 저장된 주문의 ID를 이용해 결제 처리
+    //5. 저장된 주문의 ID를 이용해 결제 처리
     OrderDTO savedOrderDTO = convertToDTO(orderEntity);
     this.payOrder(savedOrderDTO);
   }


### PR DESCRIPTION
### 개발 사항
- google style code 적용 
- Entity -> DTO, DTO -> Entity 변경 
- 주석 추가
- 주문 결제 시 재고 감소 로직 추가

### 고민점
- Entity와 DTO의 분리의 이점
```
Entity와 DTO를 분리하는 것이 도메인과 서비스 로직의 분리라고 생각하여 좋다 생각합니다.
그런데, ord_id 값을 가져오는 getter 정도는 Entity에서 사용해도 되지 않나 하는 고민이 들었습니다.
저렇게 변환하는 것을 늘상 작업에서 적용하면 부하가 올 거 같습니다.
Entity에서 getter로 값을 읽어들이는 것 정도는 사용해도 될지 고민입니다.
```