### PR TITLE
[Feat] Global exception 

### DIFF
--- a/ecService/src/main/java/com/wming/ecservice/common/exception/ErrorMessage.java
+++ b/ecService/src/main/java/com/wming/ecservice/common/exception/ErrorMessage.java
@@ -1,0 +1,19 @@
+package com.wming.ecservice.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorMessage {
+  PRODUCT_NOT_FOUND("상품이 존재하지 않습니다. 상품 이름 = %s"),
+  INSUFFICIENT_STOCK("재고가 부족합니다. 상품 이름 = %s");
+
+  private final String message;
+
+  ErrorMessage(String message) {
+    this.message = message;
+  }
+
+  public String getMessage(Object... args) {
+    return String.format(this.message, args);
+  }
+}

--- a/ecService/src/main/java/com/wming/ecservice/common/exception/GlobalExceptionHandler.java
+++ b/ecService/src/main/java/com/wming/ecservice/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.wming.ecservice.common.exception;
+
+import com.wming.ecservice.common.response.ApiResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(ResourceNotFoundException.class)
+  public ResponseEntity<ApiResponse<Void>> handleResourceNotFoundException(
+      ResourceNotFoundException e) {
+    return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.fail(e.getMessage()));
+  }
+
+}

--- a/ecService/src/main/java/com/wming/ecservice/common/exception/GlobalExceptionHandler.java
+++ b/ecService/src/main/java/com/wming/ecservice/common/exception/GlobalExceptionHandler.java
@@ -14,5 +14,4 @@ public class GlobalExceptionHandler {
       ResourceNotFoundException e) {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ApiResponse.fail(e.getMessage()));
   }
-
 }

--- a/ecService/src/main/java/com/wming/ecservice/common/exception/ResourceNotFoundException.java
+++ b/ecService/src/main/java/com/wming/ecservice/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,9 @@
+package com.wming.ecservice.common.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+
+  public ResourceNotFoundException(String message) {
+    super(message);
+  }
+  
+}

--- a/ecService/src/main/java/com/wming/ecservice/common/response/ApiResponse.java
+++ b/ecService/src/main/java/com/wming/ecservice/common/response/ApiResponse.java
@@ -1,0 +1,29 @@
+package com.wming.ecservice.common.response;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+  private boolean success;
+  private String message;
+  private T data;
+
+  public ApiResponse(boolean success, String message, T data) {
+    this.success = success;
+    this.message = message;
+    this.data = data;
+  }
+
+  public static <T> ApiResponse<T> success(T data) {
+    return new ApiResponse<>(true, "요청에 성공했습니다", data);
+  }
+
+  public static <T> ApiResponse<T> successString(String message) {
+    return new ApiResponse<>(true, message, null);
+  }
+
+  public static <T> ApiResponse<T> fail(String message) {
+    return new ApiResponse<>(false, message, null);
+  }
+}

--- a/ecService/src/main/java/com/wming/ecservice/common/success/SuccessMessage.java
+++ b/ecService/src/main/java/com/wming/ecservice/common/success/SuccessMessage.java
@@ -1,0 +1,19 @@
+package com.wming.ecservice.common.success;
+
+import lombok.Getter;
+
+@Getter
+public enum SuccessMessage {
+
+  SUCCESS_ORDER("주문이 성공했습니다.");
+
+  private final String message;
+
+  SuccessMessage(String message) {
+    this.message = message;
+  }
+
+  public String getMessage(Object... args) {
+    return String.format(this.message, args);
+  }
+}

--- a/ecService/src/main/java/com/wming/ecservice/order/controller/OrderController.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/controller/OrderController.java
@@ -1,8 +1,10 @@
 package com.wming.ecservice.order.controller;
 
+import com.wming.ecservice.common.response.ApiResponse;
 import com.wming.ecservice.order.dto.OrderRequest;
 import com.wming.ecservice.order.service.OrderSerivce;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,11 +21,11 @@ public class OrderController {
     this.orderSerivce = orderSerivce;
   }
 
-  @PostMapping("/createOrder")
-  public String createOrder(@RequestBody OrderRequest orderRequest) {
+  @PostMapping(value = "/createOrder", produces = "application/json")
+  public ResponseEntity<ApiResponse<String>> createOrder(@RequestBody OrderRequest orderRequest) {
     // 주문 정보 받는 거는  (상품 정보 product ,
     orderSerivce.createOrder(orderRequest);
-    return "주문이 완료되었습니다.";
+    return ResponseEntity.ok(ApiResponse.successString("주문이 완료 되었습니다."));
   }
 }
 

--- a/ecService/src/main/java/com/wming/ecservice/order/controller/OrderController.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.wming.ecservice.order.controller;
 
 import com.wming.ecservice.common.response.ApiResponse;
+import com.wming.ecservice.common.success.SuccessMessage;
 import com.wming.ecservice.order.dto.OrderRequest;
 import com.wming.ecservice.order.service.OrderSerivce;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +26,7 @@ public class OrderController {
   public ResponseEntity<ApiResponse<String>> createOrder(@RequestBody OrderRequest orderRequest) {
     // 주문 정보 받는 거는  (상품 정보 product ,
     orderSerivce.createOrder(orderRequest);
-    return ResponseEntity.ok(ApiResponse.successString("주문이 완료 되었습니다."));
+    return ResponseEntity.ok(ApiResponse.successString(SuccessMessage.SUCCESS_ORDER.getMessage()));
   }
 }
 

--- a/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
@@ -1,5 +1,6 @@
 package com.wming.ecservice.order.service;
 
+import com.wming.ecservice.common.exception.ErrorMessage;
 import com.wming.ecservice.common.exception.ResourceNotFoundException;
 import com.wming.ecservice.order.convert.OrderConverter;
 import com.wming.ecservice.order.dto.OrderRequest;
@@ -52,7 +53,7 @@ public class OrderSerivce {
       ProductEntity productEntity = productRepository.findById(orderProduct.getProductId())
           .orElseThrow(
               () -> new ResourceNotFoundException(
-                  "상품이 존재하지 않습니다. 상품 이름 =" + orderProduct.getProductName()));
+                  ErrorMessage.PRODUCT_NOT_FOUND.getMessage(orderProduct.getProductName())));
 
       //2. 재고 확인 및 감소
       stockService.checkStockAvailability(productEntity, orderProduct.getQuantity());

--- a/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
@@ -1,5 +1,6 @@
 package com.wming.ecservice.order.service;
 
+import com.wming.ecservice.common.exception.ResourceNotFoundException;
 import com.wming.ecservice.order.convert.OrderConverter;
 import com.wming.ecservice.order.dto.OrderRequest;
 import com.wming.ecservice.order.entity.OrderEntity;
@@ -13,9 +14,11 @@ import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 public class OrderSerivce {
 
@@ -40,6 +43,7 @@ public class OrderSerivce {
   @Transactional
   public void createOrder(OrderRequest orderRequest) {
 
+    log.info("주문 생성 시도: {}", orderRequest);
     BigDecimal totalPrice = BigDecimal.ZERO;
     List<OrderProductEntity> orderProductEntityList = new ArrayList<>();
 
@@ -47,7 +51,8 @@ public class OrderSerivce {
       //1. 상품이 존재하는지 확인
       ProductEntity productEntity = productRepository.findById(orderProduct.getProductId())
           .orElseThrow(
-              () -> new RuntimeException("상품 없음, 상품 이름 =" + orderProduct.getProductName()));
+              () -> new ResourceNotFoundException(
+                  "상품이 존재하지 않습니다. 상품 이름 =" + orderProduct.getProductName()));
 
       //2. 재고 확인 및 감소
       stockService.checkStockAvailability(productEntity, orderProduct.getQuantity());
@@ -67,6 +72,7 @@ public class OrderSerivce {
     //4. 결제 처리
     boolean paymentResult = paymentService.processPayment(totalPrice);
 
+    /*이 부분은 추후 결제 서비스 로직 개발 시 뺄 예정*/
     if (!paymentResult) {
       throw new RuntimeException("결제에 실패했습니다.");
     }

--- a/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
@@ -23,15 +23,17 @@ public class OrderSerivce {
   private final OrderConverter orderConverter;
   private ProductRepository productRepository;
   private OrderRepository orderRepository;
+  private StockService stockService;
 
   @Autowired
   public OrderSerivce(ProductRepository productRepository, OrderRepository orderRepository,
       PaymentService paymentService, OrderConverter orderConverter,
-      List<OrderProductEntity> orderProductEntityList) {
+      List<OrderProductEntity> orderProductEntityList, StockService stockService) {
     this.productRepository = productRepository;
     this.orderRepository = orderRepository;
     this.paymentService = paymentService;
     this.orderConverter = orderConverter;
+    this.stockService = stockService;
   }
 
   /*주문 생성*/
@@ -47,8 +49,8 @@ public class OrderSerivce {
           .orElseThrow(
               () -> new RuntimeException("상품 없음, 상품 이름 =" + orderProduct.getProductName()));
 
-      //2. 재고 확인
-      this.checkStockAvailability(productEntity, orderProduct.getQuantity());
+      //2. 재고 확인 및 감소
+      stockService.checkStockAvailability(productEntity, orderProduct.getQuantity());
 
       //3. 총결제 금액 계산
       BigDecimal productPrice = productEntity.getProductPrice();
@@ -75,18 +77,5 @@ public class OrderSerivce {
 
     //6. 주문 저장
     orderRepository.save(orderEntity);
-  }
-
-  /*재고 확인을 위한 메서드*/
-  private void checkStockAvailability(ProductEntity productEntity,
-      int quantity) {
-
-    // 2_1.재고 확인
-    if (!productEntity.isStockAvaliable(productEntity.getProductStock())) {
-      throw new RuntimeException("재고가 충분하지 않습니다. 상품: " + productEntity.getProductName());
-    }
-
-    // 2_2. 실제 재고 감소
-    productEntity.reduceStock(quantity);
   }
 }

--- a/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
@@ -1,0 +1,21 @@
+package com.wming.ecservice.order.service;
+
+import com.wming.ecservice.product.entity.ProductEntity;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StockService {
+
+  /*재고 확인을 위한 메서드*/
+  public void checkStockAvailability(ProductEntity productEntity,
+      int quantity) {
+
+    // 2_1.재고 확인
+    if (!productEntity.isStockAvaliable(productEntity.getProductStock())) {
+      throw new RuntimeException("재고가 충분하지 않습니다. 상품: " + productEntity.getProductName());
+    }
+
+    // 2_2. 실제 재고 감소
+    productEntity.reduceStock(quantity);
+  }
+}

--- a/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
@@ -1,5 +1,6 @@
 package com.wming.ecservice.order.service;
 
+import com.wming.ecservice.common.exception.ErrorMessage;
 import com.wming.ecservice.common.exception.ResourceNotFoundException;
 import com.wming.ecservice.product.entity.ProductEntity;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,7 @@ public class StockService {
     // 2_1.재고 확인
     if (!productEntity.isStockAvaliable(quantity)) {
       throw new ResourceNotFoundException(
-          "재고가 충분하지 않습니다. 상품 이름 =" + productEntity.getProductName());
+          ErrorMessage.INSUFFICIENT_STOCK.getMessage(productEntity.getProductName()));
     }
 
     // 2_2. 실제 재고 감소

--- a/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
@@ -1,5 +1,6 @@
 package com.wming.ecservice.order.service;
 
+import com.wming.ecservice.common.exception.ResourceNotFoundException;
 import com.wming.ecservice.product.entity.ProductEntity;
 import org.springframework.stereotype.Service;
 
@@ -11,8 +12,9 @@ public class StockService {
       int quantity) {
 
     // 2_1.재고 확인
-    if (!productEntity.isStockAvaliable(productEntity.getProductStock())) {
-      throw new RuntimeException("재고가 충분하지 않습니다. 상품: " + productEntity.getProductName());
+    if (!productEntity.isStockAvaliable(quantity)) {
+      throw new ResourceNotFoundException(
+          "재고가 충분하지 않습니다. 상품 이름 =" + productEntity.getProductName());
     }
 
     // 2_2. 실제 재고 감소

--- a/ecService/src/main/java/com/wming/ecservice/product/entity/ProductEntity.java
+++ b/ecService/src/main/java/com/wming/ecservice/product/entity/ProductEntity.java
@@ -41,7 +41,8 @@ public class ProductEntity {
   }
 
   public boolean isStockAvaliable(int quantity) {
-    return this.productStock >= quantity;
+    log.info("quantity ={}", quantity, "productStock={}", productStock);
+    return productStock > quantity;
   }
 
 }

--- a/ecService/src/main/java/com/wming/ecservice/product/entity/ProductEntity.java
+++ b/ecService/src/main/java/com/wming/ecservice/product/entity/ProductEntity.java
@@ -41,7 +41,7 @@ public class ProductEntity {
   }
 
   public boolean isStockAvaliable(int quantity) {
-    log.info("quantity ={}", quantity, "productStock={}", productStock);
+    log.info("주문 수량 ={}", quantity, "productStock={}", productStock);
     return productStock > quantity;
   }
 


### PR DESCRIPTION
1. 저번 pr때 주신 내용은 반영하지 않았고 (재고 감소 로직 등등) , error global Exception 처리 한 파일들만 올렸습니다. 
=> RestControllerAdvice를 사용해서 error가 나오면 handler를 통해 global로 exception 처리 할 수 있도록 했습니다. 
=> 성공 메시지와 에러 메시지 모두 enum으로 한 곳에서 관리할 수 있도록 모았습니다. 
=> ApiResponse를 통해서 응답값의 통일성을 줄 수 있도록 했습니다.

2. 개발하면서 고민한 점 
=> global처리와 실시간 error 처리  : 사실 그 자리에서 잡을 수 있는 exception도 있기 때문에, global로 한번에 처리하는 것에 대해서 고민을 많이 했는데 한 번에 관리할 수 있다는 것 자체가 깔끔하게 유지하기 좋을 거 같아서 global로 선택했습니다.

3. 다음 pr때 진행할 것. 
=> log AOP로 만들기 
=> 재고감소 로직 추가 
=> 지난번 pr 반영
