### PR TITLE
[Feat] 결제 실패 시 재고 감소 로직 추가

### DIFF
--- a/ecService/src/main/java/com/wming/ecservice/common/exception/FailedPaymentException.java
+++ b/ecService/src/main/java/com/wming/ecservice/common/exception/FailedPaymentException.java
@@ -1,0 +1,7 @@
+package com.wming.ecservice.common.exception;
+
+public class FailedPaymentException extends RuntimeException{
+    public FailedPaymentException(String message) {
+        super(message);
+    }
+}

--- a/ecService/src/main/java/com/wming/ecservice/common/exception/constants/ErrorMessage.java
+++ b/ecService/src/main/java/com/wming/ecservice/common/exception/constants/ErrorMessage.java
@@ -1,11 +1,12 @@
-package com.wming.ecservice.common.exception;
+package com.wming.ecservice.common.exception.constants;
 
 import lombok.Getter;
 
 @Getter
 public enum ErrorMessage {
   PRODUCT_NOT_FOUND("상품이 존재하지 않습니다. 상품 이름 = %s"),
-  INSUFFICIENT_STOCK("재고가 부족합니다. 상품 이름 = %s");
+  INSUFFICIENT_STOCK("재고가 부족합니다. 상품 이름 = %s"),
+  FAILED_PAYMENT("결제에 실패했습니다.");
 
   private final String message;
 

--- a/ecService/src/main/java/com/wming/ecservice/common/response/ApiResponse.java
+++ b/ecService/src/main/java/com/wming/ecservice/common/response/ApiResponse.java
@@ -15,11 +15,7 @@ public class ApiResponse<T> {
     this.data = data;
   }
 
-  public static <T> ApiResponse<T> success(T data) {
-    return new ApiResponse<>(true, "요청에 성공했습니다", data);
-  }
-
-  public static <T> ApiResponse<T> successString(String message) {
+  public static <T> ApiResponse<T> success(String message) {
     return new ApiResponse<>(true, message, null);
   }
 

--- a/ecService/src/main/java/com/wming/ecservice/order/controller/OrderController.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/controller/OrderController.java
@@ -24,9 +24,8 @@ public class OrderController {
 
   @PostMapping(value = "/createOrder", produces = "application/json")
   public ResponseEntity<ApiResponse<String>> createOrder(@RequestBody OrderRequest orderRequest) {
-    // 주문 정보 받는 거는  (상품 정보 product ,
     orderSerivce.createOrder(orderRequest);
-    return ResponseEntity.ok(ApiResponse.successString(SuccessMessage.SUCCESS_ORDER.getMessage()));
+    return ResponseEntity.ok(ApiResponse.success(SuccessMessage.SUCCESS_ORDER.getMessage()));
   }
 }
 

--- a/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
@@ -1,6 +1,7 @@
 package com.wming.ecservice.order.service;
 
-import com.wming.ecservice.common.exception.ErrorMessage;
+import com.wming.ecservice.common.exception.FailedPaymentException;
+import com.wming.ecservice.common.exception.constants.ErrorMessage;
 import com.wming.ecservice.common.exception.ResourceNotFoundException;
 import com.wming.ecservice.order.convert.OrderConverter;
 import com.wming.ecservice.order.dto.OrderRequest;
@@ -15,6 +16,9 @@ import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -45,15 +49,27 @@ public class OrderSerivce {
   public void createOrder(OrderRequest orderRequest) {
 
     log.info("주문 생성 시도: {}", orderRequest);
+
     BigDecimal totalPrice = BigDecimal.ZERO;
     List<OrderProductEntity> orderProductEntityList = new ArrayList<>();
 
+    //1. 모든 상품 ProductId를 가져와 한 번에 조회
+    List<Long> productIds = orderRequest.getOrderProducts().stream()
+            .map(OrderProductRequest::getProductId)
+            .collect(Collectors.toList());
+
+    Map<Long, ProductEntity> productEntityMap = productRepository.findAllById(productIds)
+            .stream()
+            .collect(Collectors.toMap(ProductEntity::getProductId, productEntity -> productEntity));
+
     for (OrderProductRequest orderProduct : orderRequest.getOrderProducts()) {
-      //1. 상품이 존재하는지 확인
-      ProductEntity productEntity = productRepository.findById(orderProduct.getProductId())
-          .orElseThrow(
-              () -> new ResourceNotFoundException(
-                  ErrorMessage.PRODUCT_NOT_FOUND.getMessage(orderProduct.getProductName())));
+
+      //1. 상품 존재 확인
+      ProductEntity productEntity = productEntityMap.get(orderProduct.getProductId());
+      if(productEntity == null) {
+        throw new ResourceNotFoundException(
+                ErrorMessage.PRODUCT_NOT_FOUND.getMessage(orderProduct.getProductName()));
+      }
 
       //2. 재고 확인 및 감소
       stockService.checkAndReduceStock(productEntity, orderProduct.getQuantity());
@@ -63,7 +79,7 @@ public class OrderSerivce {
       BigDecimal quantity = BigDecimal.valueOf(orderProduct.getQuantity());
       totalPrice = totalPrice.add(productPrice.multiply(quantity));
 
-      //4. OrderProductEntity 생성해주기
+      //4. OrderProductEntity 생성
       orderProductEntityList.add(
           new OrderProductEntity(productEntity, productEntity.getProductPrice(),
               orderProduct.getQuantity())
@@ -73,9 +89,9 @@ public class OrderSerivce {
     //4. 결제 처리
     boolean paymentResult = paymentService.processPayment(totalPrice);
 
-    /*이 부분은 추후 결제 서비스 로직 개발 시 뺄 예정*/
     if (!paymentResult) {
-      throw new RuntimeException("결제에 실패했습니다.");
+          stockService.restoreStock(productEntityMap,orderRequest.getOrderProducts());
+      throw new FailedPaymentException(ErrorMessage.FAILED_PAYMENT.getMessage());
     }
 
     //5. 조회된 상품들과 DTO를 바탕으로 OrderEntity를 생성

--- a/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
@@ -1,8 +1,8 @@
 package com.wming.ecservice.order.service;
 
 import com.wming.ecservice.common.exception.FailedPaymentException;
-import com.wming.ecservice.common.exception.constants.ErrorMessage;
 import com.wming.ecservice.common.exception.ResourceNotFoundException;
+import com.wming.ecservice.common.exception.constants.ErrorMessage;
 import com.wming.ecservice.order.convert.OrderConverter;
 import com.wming.ecservice.order.dto.OrderRequest;
 import com.wming.ecservice.order.entity.OrderEntity;
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -55,20 +54,20 @@ public class OrderSerivce {
 
     //1. 모든 상품 ProductId를 가져와 한 번에 조회
     List<Long> productIds = orderRequest.getOrderProducts().stream()
-            .map(OrderProductRequest::getProductId)
-            .collect(Collectors.toList());
+        .map(OrderProductRequest::getProductId)
+        .collect(Collectors.toList());
 
     Map<Long, ProductEntity> productEntityMap = productRepository.findAllById(productIds)
-            .stream()
-            .collect(Collectors.toMap(ProductEntity::getProductId, productEntity -> productEntity));
+        .stream()
+        .collect(Collectors.toMap(ProductEntity::getProductId, productEntity -> productEntity));
 
     for (OrderProductRequest orderProduct : orderRequest.getOrderProducts()) {
 
       //1. 상품 존재 확인
       ProductEntity productEntity = productEntityMap.get(orderProduct.getProductId());
-      if(productEntity == null) {
+      if (productEntity == null) {
         throw new ResourceNotFoundException(
-                ErrorMessage.PRODUCT_NOT_FOUND.getMessage(orderProduct.getProductName()));
+            ErrorMessage.PRODUCT_NOT_FOUND.getMessage(orderProduct.getProductName()));
       }
 
       //2. 재고 확인 및 감소
@@ -90,7 +89,6 @@ public class OrderSerivce {
     boolean paymentResult = paymentService.processPayment(totalPrice);
 
     if (!paymentResult) {
-          stockService.restoreStock(productEntityMap,orderRequest.getOrderProducts());
       throw new FailedPaymentException(ErrorMessage.FAILED_PAYMENT.getMessage());
     }
 

--- a/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
@@ -56,7 +56,7 @@ public class OrderSerivce {
                   ErrorMessage.PRODUCT_NOT_FOUND.getMessage(orderProduct.getProductName())));
 
       //2. 재고 확인 및 감소
-      stockService.checkStockAvailability(productEntity, orderProduct.getQuantity());
+      stockService.checkAndReduceStock(productEntity, orderProduct.getQuantity());
 
       //3. 총결제 금액 계산
       BigDecimal productPrice = productEntity.getProductPrice();

--- a/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
@@ -1,24 +1,36 @@
 package com.wming.ecservice.order.service;
 
-import com.wming.ecservice.common.exception.ErrorMessage;
+import com.wming.ecservice.common.exception.constants.ErrorMessage;
 import com.wming.ecservice.common.exception.ResourceNotFoundException;
+import com.wming.ecservice.orderproduct.dto.OrderProductRequest;
 import com.wming.ecservice.product.entity.ProductEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 public class StockService {
 
-  /*재고 확인을 위한 메서드*/
+  /* 재고 확인 및 감소 */
   public void checkAndReduceStock(ProductEntity productEntity,
       int quantity) {
 
-    // 2_1.재고 확인
     if (!productEntity.isStockAvaliable(quantity)) {
       throw new ResourceNotFoundException(
           ErrorMessage.INSUFFICIENT_STOCK.getMessage(productEntity.getProductName()));
     }
 
-    // 2_2. 실제 재고 감소
     productEntity.reduceStock(quantity);
+  }
+
+  /* 결제 실패 시, 재고 복구 */
+  public void restoreStock(Map<Long, ProductEntity> productEntityMap, List<OrderProductRequest> orderProductRequests) {
+      for(OrderProductRequest orderProductRequest : orderProductRequests) {
+        ProductEntity productEntity = productEntityMap.get(orderProductRequest.getProductId());
+        if(productEntity != null) {
+          productEntity.increaseStock(orderProductRequest.getQuantity());
+        }
+      }
   }
 }

--- a/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
@@ -1,13 +1,9 @@
 package com.wming.ecservice.order.service;
 
-import com.wming.ecservice.common.exception.constants.ErrorMessage;
 import com.wming.ecservice.common.exception.ResourceNotFoundException;
-import com.wming.ecservice.orderproduct.dto.OrderProductRequest;
+import com.wming.ecservice.common.exception.constants.ErrorMessage;
 import com.wming.ecservice.product.entity.ProductEntity;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.Map;
 
 @Service
 public class StockService {
@@ -22,15 +18,5 @@ public class StockService {
     }
 
     productEntity.reduceStock(quantity);
-  }
-
-  /* 결제 실패 시, 재고 복구 */
-  public void restoreStock(Map<Long, ProductEntity> productEntityMap, List<OrderProductRequest> orderProductRequests) {
-      for(OrderProductRequest orderProductRequest : orderProductRequests) {
-        ProductEntity productEntity = productEntityMap.get(orderProductRequest.getProductId());
-        if(productEntity != null) {
-          productEntity.increaseStock(orderProductRequest.getQuantity());
-        }
-      }
   }
 }

--- a/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 public class StockService {
 
   /*재고 확인을 위한 메서드*/
-  public void checkStockAvailability(ProductEntity productEntity,
+  public void checkAndReduceStock(ProductEntity productEntity,
       int quantity) {
 
     // 2_1.재고 확인

--- a/ecService/src/main/java/com/wming/ecservice/payment/service/PaymentService.java
+++ b/ecService/src/main/java/com/wming/ecservice/payment/service/PaymentService.java
@@ -1,12 +1,16 @@
 package com.wming.ecservice.payment.service;
 
 import java.math.BigDecimal;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 public class PaymentService {
 
   public boolean processPayment(BigDecimal totalPrice) {
+    log.info("결제 성공");
     return true;
   }
 }

--- a/ecService/src/main/java/com/wming/ecservice/product/entity/ProductEntity.java
+++ b/ecService/src/main/java/com/wming/ecservice/product/entity/ProductEntity.java
@@ -37,7 +37,12 @@ public class ProductEntity {
 
   public void reduceStock(int quantity) {
     this.productStock -= quantity;
-    log.debug("재고 감소 완료 : productStock={}", productStock);
+    log.info("재고 감소 완료 : productStock={}", productStock);
+  }
+
+  public void increaseStock(int quantity) {
+    this.productStock += quantity;
+    log.info("재고 증가 완료 : productStock={}", productStock);
   }
 
   public boolean isStockAvaliable(int quantity) {

--- a/ecService/src/main/java/com/wming/ecservice/product/entity/ProductEntity.java
+++ b/ecService/src/main/java/com/wming/ecservice/product/entity/ProductEntity.java
@@ -41,7 +41,6 @@ public class ProductEntity {
   }
 
   public boolean isStockAvaliable(int quantity) {
-    log.info("주문 수량 ={}", quantity, "productStock={}", productStock);
     return productStock > quantity;
   }
 


### PR DESCRIPTION
### 질문 
1. 결제 실패 시 재고 감소 로직에 대한 구상 pr을 받고 개발을 했는데 
개발을 하다보니 Transacional 어노테이션 안에서 진행되는 것이라 결제 실패 시 자동 롤백되는데 
어떤 이유로 추가하라하신 건지 여쭤보고싶습니다. !! 
=> 결제 실패 시 실제 DB에도 다시 롤백되는 것을 확인했습니다.

### 변경 점

1. 결제 실패시 재고 복구에 대한 로직 추가

2. 상품의 존재여부 확인 findByAll로 변경 
    => 기존에는 상품의 갯수 만큼 for문을 돌며 DB를 확인해야 하기 때문에 한 번에 조회하는 것으로 변경. 
    => 추후, visualVM을 통해 성능 테스트 해 볼 예정

3. isStockAvaliable의 필요없는 로그 제거

4. 주석 필요없는 것 삭제 

5. checkStockAvailability 이름 변경 