### PR TITLE
[Test] 주문 서비스 단위 테스트 (재고 감소 동시성 테스트, 결제 실패 시 재고 원복 테스트)

### DIFF
--- a/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/OrderSerivce.java
@@ -97,6 +97,7 @@ public class OrderSerivce {
         totalPrice);
 
     //6. 주문 저장
+    log.info("주문 저장 : {}" , orderEntity.getOrderId());
     orderRepository.save(orderEntity);
   }
 }

--- a/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
+++ b/ecService/src/main/java/com/wming/ecservice/order/service/StockService.java
@@ -8,15 +8,14 @@ import org.springframework.stereotype.Service;
 @Service
 public class StockService {
 
-  /* 재고 확인 및 감소 */
   public void checkAndReduceStock(ProductEntity productEntity,
       int quantity) {
-
-    if (!productEntity.isStockAvaliable(quantity)) {
-      throw new ResourceNotFoundException(
-          ErrorMessage.INSUFFICIENT_STOCK.getMessage(productEntity.getProductName()));
+    synchronized (productEntity) {
+      if (!productEntity.isStockAvaliable(quantity)) {
+        throw new ResourceNotFoundException(
+            ErrorMessage.INSUFFICIENT_STOCK.getMessage(productEntity.getProductName()));
+      }
+      productEntity.reduceStock(quantity);
     }
-
-    productEntity.reduceStock(quantity);
   }
 }

--- a/ecService/src/main/java/com/wming/ecservice/product/entity/ProductEntity.java
+++ b/ecService/src/main/java/com/wming/ecservice/product/entity/ProductEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 @Entity
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @Slf4j
 public class ProductEntity {
 
@@ -46,7 +48,7 @@ public class ProductEntity {
   }
 
   public boolean isStockAvaliable(int quantity) {
-    return productStock > quantity;
+    return productStock >= quantity;
   }
 
 }

--- a/ecService/src/test/java/com/wming/ecservice/order/OrderServiceConcurrencyTest.java
+++ b/ecService/src/test/java/com/wming/ecservice/order/OrderServiceConcurrencyTest.java
@@ -1,68 +1,73 @@
 package com.wming.ecservice.order;
 
-import com.wming.ecservice.order.dto.OrderRequest;
-import com.wming.ecservice.order.service.OrderSerivce;
-import com.wming.ecservice.orderproduct.dto.OrderProductRequest;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.wming.ecservice.common.exception.ResourceNotFoundException;
+import com.wming.ecservice.order.service.StockService;
 import com.wming.ecservice.product.entity.ProductEntity;
 import com.wming.ecservice.product.repository.ProductRepository;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-
-import java.util.ArrayList;
-import java.util.List;
+import java.math.BigDecimal;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
 
 
 @SpringBootTest
 public class OrderServiceConcurrencyTest {
 
-    @Autowired
-    private OrderSerivce orderSerivce;
+  @Autowired
+  private StockService stockService;
 
-    @Autowired
-    private ProductRepository productRepository;
+  @Autowired
+  private ProductRepository productRepository;
 
-    @Test
-    @DisplayName("동시에 같은 상품의 재고를 확인하고 감소시키려 할 때")
-    public void testConcurrentOrders() throws InterruptedException {
+  @RepeatedTest(20)
+  @Test
+  @DisplayName("동시에 같은 상품의 재고를 확인하고 감소시키려 할 때")
+  public void testConcurrentOrders() throws InterruptedException {
 
-        //Given
-        int numberOfThreads = 1000;
-        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
-        CountDownLatch latch = new CountDownLatch(numberOfThreads);
-        List<Future<?>> futures = new ArrayList<>(); //스레드의 결과 저장할 Future객체
+    //Given
+    int numberOfThreads = 200;
+    int reduceStock = 5;
+    ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+    CountDownLatch latch = new CountDownLatch(1); // 시작 신호를 위한 latch
+    AtomicInteger successfulReductions = new AtomicInteger(0);
+    AtomicInteger failedReductions = new AtomicInteger(0);
+    ProductEntity productEntity = new ProductEntity(1L, "상품1", "테스트상품입니답", new BigDecimal("25000"),
+        200);
 
-        //When : 여러 스레드가 동시에 주문을 생성
-        for(int i = 0 ; i < numberOfThreads; i++) {
+    //When : 여러 스레드가 동시에 주문을 생성
+    for (int i = 0; i < numberOfThreads; i++) {
+      executorService.execute(() -> {
+        try {
+          latch.await(); //모든 스레드가 준비될 때까지 대기
+          Thread.sleep((int) (Math.random() * 10));// 인위적으로 딜레이를 추가하여 경합 상태를 유발
 
-            futures.add(executorService.submit(() -> {
+          stockService.checkAndReduceStock(productEntity, reduceStock);
+          successfulReductions.incrementAndGet();
 
-                try {
-                    List<OrderProductRequest> OrderProductRequests = new ArrayList<>();
-                    OrderProductRequests.add(new OrderProductRequest(1L, "product_1" , 30));
-                    OrderRequest orderRequest = new OrderRequest(OrderProductRequests);
-                    orderSerivce.createOrder(orderRequest);
-                } catch (Exception e) {
-                    System.out.println("스레드 예외 발생 " + e.getMessage());
-                } finally {
-                    latch.countDown();
-                }
-            }));
+        } catch (ResourceNotFoundException e) {
+          failedReductions.incrementAndGet();
+        } catch (Exception e) {
+          Thread.currentThread().interrupt();
         }
-
-        latch.await();
-        executorService.shutdown();
-
-        ProductEntity productEntity = productRepository.findById(1L).get();
-        System.out.println("최종 재고: " + productEntity.getProductStock());
-
-        assertTrue(productEntity.getProductStock() >= 0, "재고는 음수가 될 수 없음");
+      });
     }
+
+    latch.countDown(); // 모든 스레드에 시작 신호
+    executorService.shutdown();
+    Thread.sleep(1000); // 스레드들이 모두 끝날 때까지 대기
+
+    // Then: 40개의 스레드는 성공, 160개의 스레드는 실패해야 함
+    assertEquals(40, successfulReductions.get(), "성공한 스레드 수가 예상과 다름");
+    assertEquals(160, failedReductions.get(), "실패한 스레드 수가 예상과 다름");
+    assertEquals(0, productEntity.getProductStock(), "재고가 0이 되어야 함");
+
+  }
 }

--- a/ecService/src/test/java/com/wming/ecservice/order/OrderServiceConcurrencyTest.java
+++ b/ecService/src/test/java/com/wming/ecservice/order/OrderServiceConcurrencyTest.java
@@ -1,0 +1,68 @@
+package com.wming.ecservice.order;
+
+import com.wming.ecservice.order.dto.OrderRequest;
+import com.wming.ecservice.order.service.OrderSerivce;
+import com.wming.ecservice.orderproduct.dto.OrderProductRequest;
+import com.wming.ecservice.product.entity.ProductEntity;
+import com.wming.ecservice.product.repository.ProductRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+@SpringBootTest
+public class OrderServiceConcurrencyTest {
+
+    @Autowired
+    private OrderSerivce orderSerivce;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Test
+    @DisplayName("동시에 같은 상품의 재고를 확인하고 감소시키려 할 때")
+    public void testConcurrentOrders() throws InterruptedException {
+
+        //Given
+        int numberOfThreads = 1000;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+        List<Future<?>> futures = new ArrayList<>(); //스레드의 결과 저장할 Future객체
+
+        //When : 여러 스레드가 동시에 주문을 생성
+        for(int i = 0 ; i < numberOfThreads; i++) {
+
+            futures.add(executorService.submit(() -> {
+
+                try {
+                    List<OrderProductRequest> OrderProductRequests = new ArrayList<>();
+                    OrderProductRequests.add(new OrderProductRequest(1L, "product_1" , 30));
+                    OrderRequest orderRequest = new OrderRequest(OrderProductRequests);
+                    orderSerivce.createOrder(orderRequest);
+                } catch (Exception e) {
+                    System.out.println("스레드 예외 발생 " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            }));
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        ProductEntity productEntity = productRepository.findById(1L).get();
+        System.out.println("최종 재고: " + productEntity.getProductStock());
+
+        assertTrue(productEntity.getProductStock() >= 0, "재고는 음수가 될 수 없음");
+    }
+}


### PR DESCRIPTION
### 개발한 건 
1. 동시성 테스트
```
- 여러 개의 스레드에서 동시다발적으로 같은 상품의 재고를 감소시키는 상황으로 동시성 문제 발생 
- synchronized block 을 통해 재고 체크 및 감소하는 메소드 락 
```

2. 지난번 pr 재고 원복 로직 삭제 
```
- transactional 키워드를 통해 재고 원복 로직이 없어도 원복 되는 것 확인 
- 그에 대한 test code 작성
```

### 고민한 점 
```
1. synchronized가 최선인가 
=> 분산 락, 트랜잭션 격리수준 설정 등등 생각해보았지만, 단일 JVM과 인스턴스라는 점, 그 안의 메모리에서만 생기는 동시성 문제이기 때문에
synchronized가 제일 좋을 것 같다 생각. 

2.  재고 원복은 동시성 문제가 생기지 않는가 ? 
=> 애초에 transactional 어노테이션에 묶여있어 발생하지 않을 것이라 생각.
```